### PR TITLE
Add GitHub Skills activity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills with GitHub",
+        "schedule": "Wednesdays, 3:30 PM - 5:30 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
This pull request adds the "GitHub Skills" activity to the system. The activity includes the following details:

- **Description**: Learn practical coding and collaboration skills with GitHub.
- **Schedule**: Wednesdays, 3:30 PM - 5:30 PM.
- **Maximum Participants**: 25.

This change addresses the issue of the missing "GitHub Skills" activity as announced by the principal.